### PR TITLE
Update Widget IDs after today's update.

### DIFF
--- a/src/main/java/com/logmaster/ui/InterfaceManager.java
+++ b/src/main/java/com/logmaster/ui/InterfaceManager.java
@@ -89,7 +89,7 @@ public class InterfaceManager {
     }
 
     public void handleCollectionLogOpen() {
-        Widget window = client.getWidget(40697857);
+        Widget window = client.getWidget(621, 88);
 
         Widget dashboardTabWidget = window.createChild(-1, WidgetType.GRAPHIC);
         taskDashboardTab = new UIButton(dashboardTabWidget);
@@ -176,7 +176,7 @@ public class InterfaceManager {
     }
 
     private void createTaskCheckbox() {
-        Widget window = client.getWidget(40697857);
+        Widget window = client.getWidget(621, 88);
         if (window != null) {
             // Create the graphic widget for the checkbox
             Widget toggleWidget = window.createChild(-1, WidgetType.GRAPHIC);


### PR DESCRIPTION
Works perfectly in fixed mode.

Resizing or moving the collection log window in resizeable mode while the task dashboard is open will repaint the collection log under it. Also, the Task Dashboard toggle can end up overlapping the title text. Toggling the task dashboard off and on again, or reopening the collection log fixes these issues.