### PR TITLE
replace checkbox with option in window dropdown for opening task dashboard (fixes #29)

### DIFF
--- a/src/main/java/com/logmaster/LogMasterPlugin.java
+++ b/src/main/java/com/logmaster/LogMasterPlugin.java
@@ -28,6 +28,9 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.input.MouseManager;
 import net.runelite.client.input.MouseWheelListener;
+import net.runelite.client.menus.MenuManager;
+import net.runelite.client.menus.WidgetMenuOption;
+import net.runelite.api.events.ScriptPostFired;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -49,6 +52,7 @@ import java.util.stream.Collectors;
 public class LogMasterPlugin extends Plugin implements MouseWheelListener {
 	private static final String TASK_CHAT_COMMAND = "!tasker";
 
+    private static final int COLLECTION_LOG_SETUP_SCRIPT_ID = 7797;
 
 	@Inject
 	private Client client;
@@ -140,6 +144,13 @@ public class LogMasterPlugin extends Plugin implements MouseWheelListener {
 			interfaceManager.handleCollectionLogClose();
 		}
 	}
+
+    @Subscribe
+    public void onScriptPostFired(ScriptPostFired scriptPostFired) {
+        if (scriptPostFired.getScriptId() == COLLECTION_LOG_SETUP_SCRIPT_ID) {
+            interfaceManager.handleCollectionLogScriptRan();
+        }
+    }
 
 	@Subscribe
 	public void onGameTick(GameTick event) {

--- a/src/main/java/com/logmaster/ui/InterfaceManager.java
+++ b/src/main/java/com/logmaster/ui/InterfaceManager.java
@@ -9,6 +9,7 @@ import com.logmaster.persistence.SaveDataManager;
 import com.logmaster.task.TaskService;
 import com.logmaster.ui.component.TaskDashboard;
 import com.logmaster.ui.component.TaskList;
+import com.logmaster.ui.generic.UICheckBox;
 import com.logmaster.ui.generic.dropdown.UIDropdown;
 import com.logmaster.ui.generic.dropdown.UIDropdownOption;
 import com.logmaster.ui.generic.UIButton;
@@ -67,6 +68,7 @@ public class InterfaceManager {
     private List<UIButton> tabs;
     private UIButton taskListTab;
     private UIButton taskDashboardTab;
+    private UICheckBox taskDashboardCheckbox;
     private UIDropdown dropdown;
 
     public void initialise() {
@@ -142,6 +144,7 @@ public class InterfaceManager {
 
         createTaskDashboard(window);
         createTaskList(window);
+        createTaskCheckbox();
         updateTabs();
 
         this.taskDashboard.setVisibility(false);
@@ -191,6 +194,30 @@ public class InterfaceManager {
         this.dropdown = new UIDropdown(container);
         this.dropdown.addOption("Tasks", "View Tasks Dashboard");
         this.dropdown.setOptionEnabledListener(this::toggleTaskDashboard);
+    }
+
+    private void createTaskCheckbox() {
+        Widget window = client.getWidget(621, 88);
+        if (window != null) {
+            // Create the graphic widget for the checkbox
+            Widget toggleWidget = window.createChild(-1, WidgetType.GRAPHIC);
+            Widget labelWidget = window.createChild(-1, WidgetType.TEXT);
+
+            // Wrap in checkbox, set size, position, etc.
+            taskDashboardCheckbox = new UICheckBox(toggleWidget, labelWidget);
+            taskDashboardCheckbox.setPosition(360, 10);
+            taskDashboardCheckbox.setName("Task Dashboard");
+            taskDashboardCheckbox.setEnabled(false);
+            taskDashboardCheckbox.setText("Task Dashboard");
+            labelWidget.setPos(375, 10);
+            taskDashboardCheckbox.setToggleListener((UICheckBox src) -> {
+                if (taskDashboardCheckbox.isEnabled()) {
+                    this.dropdown.setEnabledOption("Tasks");
+                } else {
+                    this.dropdown.setEnabledOption("View Log");
+                }
+            });
+        }
     }
 
     private void updateTabs() {
@@ -246,6 +273,7 @@ public class InterfaceManager {
             plugin.nullCurrentTask();
         }
 
+        this.taskDashboardCheckbox.setEnabled(isTaskDashboardEnabled());
         client.getWidget(COLLECTION_LOG_CONTENT_WIDGET_ID).setHidden(isTaskDashboardEnabled());
         client.getWidget(40697936).setHidden(isTaskDashboardEnabled());
 

--- a/src/main/java/com/logmaster/ui/InterfaceManager.java
+++ b/src/main/java/com/logmaster/ui/InterfaceManager.java
@@ -159,7 +159,7 @@ public class InterfaceManager {
             this.dropdown = null;
         }
 
-        createTaskDropdwnOption();
+        createTaskDropdownOption();
     }
 
     public boolean isDashboardOpen() {
@@ -182,7 +182,7 @@ public class InterfaceManager {
         this.taskDashboard.disableGenerateTask();
     }
 
-    private void createTaskDropdwnOption() {
+    private void createTaskDropdownOption() {
         Widget container = client.getWidget(COLLECTION_LOG_TAB_DROPDOWN_WIDGET_ID);
         if (container == null) {
             return;

--- a/src/main/java/com/logmaster/ui/InterfaceManager.java
+++ b/src/main/java/com/logmaster/ui/InterfaceManager.java
@@ -190,7 +190,7 @@ public class InterfaceManager {
 
         this.dropdown = new UIDropdown(container);
         this.dropdown.addOption("Tasks", "View Tasks Dashboard");
-        this.dropdown.setTabEnabledListener(this::toggleTaskDashboard);
+        this.dropdown.setOptionEnabledListener(this::toggleTaskDashboard);
     }
 
     private void updateTabs() {

--- a/src/main/java/com/logmaster/ui/generic/ComponentEventListener.java
+++ b/src/main/java/com/logmaster/ui/generic/ComponentEventListener.java
@@ -4,12 +4,12 @@ package com.logmaster.ui.generic;
  * A listener interface for receiving UI component events
  * @author Antipixel
  */
-public interface ComponentEventListener
+public interface ComponentEventListener<T extends UIComponent>
 {
 	/**
 	 * Invoked upon a component event
 	 * @param src the source component responsible for the event
 	 */
-	void onComponentEvent(UIComponent src);
+	void onComponentEvent(T src);
 }
 

--- a/src/main/java/com/logmaster/ui/generic/UICheckBox.java
+++ b/src/main/java/com/logmaster/ui/generic/UICheckBox.java
@@ -33,7 +33,7 @@ public class UICheckBox extends UIComponent
 	private boolean hovering;
 
 	@Setter
-	private ComponentEventListener toggleListener;
+	private ComponentEventListener<UICheckBox> toggleListener;
 
 	/**
 	 * Constructs a new checkbox component

--- a/src/main/java/com/logmaster/ui/generic/UIComponent.java
+++ b/src/main/java/com/logmaster/ui/generic/UIComponent.java
@@ -21,10 +21,10 @@ public abstract class UIComponent
 	private static final String BTN_NAME_FORMAT = "<col=ff9040>%s</col>";
 
 	@Getter
-	private Widget widget;
+	protected Widget widget;
 
 	/* Actions and events */
-	private List<MenuAction> actions;
+	protected List<MenuAction> actions;
 
 	@Setter
 	private ComponentEventListener<UIComponent> hoverListener;

--- a/src/main/java/com/logmaster/ui/generic/UIComponent.java
+++ b/src/main/java/com/logmaster/ui/generic/UIComponent.java
@@ -8,6 +8,7 @@ import net.runelite.api.widgets.Widget;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * UI Component classes allow for complex user interface functionality by
@@ -46,6 +47,15 @@ public abstract class UIComponent
 		this.widget.setHasListener(true);
 
 		this.actions = new ArrayList<>();
+	}
+
+	public UIComponent(Widget widget, Set<Integer> allowedTypes) {
+		this(widget);
+
+		if (!allowedTypes.contains(widget.getType())) {
+			String msg = String.format("Incompatible widget's type given; %s given, %d expected", allowedTypes, widget.getType());
+			throw new RuntimeException(msg);
+		}
 	}
 
 	/**

--- a/src/main/java/com/logmaster/ui/generic/UIComponent.java
+++ b/src/main/java/com/logmaster/ui/generic/UIComponent.java
@@ -149,6 +149,12 @@ public abstract class UIComponent
 		this.widget.setOriginalHeight(height);
 	}
 
+	public void setSizeMode(int widthMode, int heightMode)
+	{
+		this.widget.setWidthMode(widthMode);
+		this.widget.setHeightMode(heightMode);
+	}
+
 	/**
 	 * Sets the position of the component, relative
 	 * to the parent layer widget
@@ -244,5 +250,9 @@ public abstract class UIComponent
 
 	public void clearActions() {
 		actions.clear();
+	}
+
+	public void revalidate() {
+		this.widget.revalidate();
 	}
 }

--- a/src/main/java/com/logmaster/ui/generic/UIComponent.java
+++ b/src/main/java/com/logmaster/ui/generic/UIComponent.java
@@ -26,10 +26,10 @@ public abstract class UIComponent
 	private List<MenuAction> actions;
 
 	@Setter
-	private ComponentEventListener hoverListener;
+	private ComponentEventListener<UIComponent> hoverListener;
 
 	@Setter
-	private ComponentEventListener leaveListener;
+	private ComponentEventListener<UIComponent> leaveListener;
 
 	/**
 	 * Constructs a new UIComponent
@@ -104,7 +104,7 @@ public abstract class UIComponent
 	 * hovering over the widget
 	 * @param listener the listener
 	 */
-	public void setOnHoverListener(ComponentEventListener listener)
+	public void setOnHoverListener(ComponentEventListener<UIComponent> listener)
 	{
 		this.hoverListener = listener;
 	}
@@ -114,7 +114,7 @@ public abstract class UIComponent
 	 * exiting from over the widget
 	 * @param listener the listener
 	 */
-	public void setOnLeaveListener(ComponentEventListener listener)
+	public void setOnLeaveListener(ComponentEventListener<UIComponent> listener)
 	{
 		this.leaveListener = listener;
 	}

--- a/src/main/java/com/logmaster/ui/generic/UIComponent.java
+++ b/src/main/java/com/logmaster/ui/generic/UIComponent.java
@@ -80,7 +80,7 @@ public abstract class UIComponent
 		if (this.actions.isEmpty())
 			return;
 
-		// Get the action action event object for this menu option
+		// Get the action event object for this menu option
 		MenuAction actionEvent = this.actions.get(e.getOp() - 1);
 
 		// Call the action listener for this option

--- a/src/main/java/com/logmaster/ui/generic/dropdown/UIDropdown.java
+++ b/src/main/java/com/logmaster/ui/generic/dropdown/UIDropdown.java
@@ -19,7 +19,7 @@ public class UIDropdown extends UIComponent {
     private final List<UIDropdownOption> options;
 
 	@Setter
-	private ComponentEventListener<UIDropdownOption> tabEnabledListener;
+	private ComponentEventListener<UIDropdownOption> optionEnabledListener;
 
 	public UIDropdown(Widget widget) {
 		super(widget, Set.of(WidgetType.LAYER));
@@ -43,7 +43,7 @@ public class UIDropdown extends UIComponent {
                 // directly succeeded by the matching text widget
                 Widget textWidget = children[c.getIndex() + 1];
                 UIDropdownOption option = new UIDropdownOption(c, textWidget);
-                option.setEnabledListener(this::onTabEnabled);
+                option.setEnabledListener(this::onOptionEnabled);
                 this.options.add(option);
             }
         }
@@ -101,14 +101,14 @@ public class UIDropdown extends UIComponent {
         newOption.setText(text);
         newOption.setActionText(actionText);
         newOption.revalidate();
-        newOption.setEnabledListener(this::onTabEnabled);
+        newOption.setEnabledListener(this::onOptionEnabled);
 
         this.options.add(newOption);
 
         resizeTabsContainer();
     }
 
-    void onTabEnabled(UIDropdownOption src) {
+    void onOptionEnabled(UIDropdownOption src) {
         for (UIDropdownOption ui : this.options) {
             if (ui == src) continue;
             ui.setEnabled(false);
@@ -118,8 +118,8 @@ public class UIDropdown extends UIComponent {
         this.widget.setHidden(true)
             .revalidate();
 
-        if (this.tabEnabledListener != null) {
-            this.tabEnabledListener.onComponentEvent(src);
+        if (this.optionEnabledListener != null) {
+            this.optionEnabledListener.onComponentEvent(src);
         }
     }
 

--- a/src/main/java/com/logmaster/ui/generic/dropdown/UIDropdown.java
+++ b/src/main/java/com/logmaster/ui/generic/dropdown/UIDropdown.java
@@ -1,0 +1,143 @@
+package com.logmaster.ui.generic.dropdown;
+
+import com.logmaster.ui.generic.ComponentEventListener;
+import com.logmaster.ui.generic.UIComponent;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetType;
+
+import java.util.*;
+
+@Slf4j
+public class UIDropdown extends UIComponent {
+    private static final int BORDER_WIDTH = 6;
+
+    // TODO: find a better way to identify our widgets
+    public static final String WIDGET_NAME = "clogmaster";
+
+    private final List<UIDropdownOption> options;
+
+	@Setter
+	private ComponentEventListener<UIDropdownOption> tabEnabledListener;
+
+	public UIDropdown(Widget widget) {
+		super(widget, Set.of(WidgetType.LAYER));
+        this.options = new ArrayList<>();
+        this.setup();
+	}
+
+    private void setup() {
+        Widget[] children = this.widget.getChildren();
+        if (children == null) {
+            return;
+        }
+
+        for (Widget c : children) {
+            if (!c.getName().isEmpty()) {
+                continue;
+            }
+
+            if (c.getType() == WidgetType.RECTANGLE) {
+                // we assume every background (rectangle) widget is
+                // directly succeeded by the matching text widget
+                Widget textWidget = children[c.getIndex() + 1];
+                UIDropdownOption option = new UIDropdownOption(c, textWidget);
+                option.setEnabledListener(this::onTabEnabled);
+                this.options.add(option);
+            }
+        }
+    }
+
+    public void cleanup() {
+        Widget tabContainer = this.widget;
+        Widget[] children = tabContainer.getChildren();
+        if (children == null || children.length == 0) {
+            return;
+        }
+
+        for (UIDropdownOption opt : this.options) {
+            if (!opt.isManaged()) continue;
+
+            children[opt.getWidget().getIndex()] = null;
+        }
+
+        Widget[] newChildren = Arrays.stream(children)
+            .filter(Objects::nonNull)
+            .toArray(Widget[]::new);
+
+        Widget[] nzNewChildren = Arrays.copyOf(children, newChildren.length);
+        System.arraycopy(newChildren, 0, nzNewChildren, 0, newChildren.length);
+
+        tabContainer.setChildren(nzNewChildren);
+        tabContainer.revalidate();
+
+        resizeTabsContainer();
+    }
+
+    public UIDropdownOption getEnabledOption() {
+        for (UIDropdownOption opt : this.options) {
+            if (opt.isEnabled()) {
+                return opt;
+            }
+        }
+
+        return null;
+    }
+
+    public void addOption(String text, String actionText) {
+        Widget tabContainer = this.widget;
+        Widget[] children = tabContainer.getChildren();
+        if (children == null || children.length == 0) {
+            return;
+        }
+
+        Widget lastOption = this.options.get(this.options.size() - 1).getWidget();
+
+        UIDropdownOption newOption = new UIDropdownOption(tabContainer.createChild(WidgetType.LAYER));
+        newOption.setName(WIDGET_NAME);
+        newOption.setSize(lastOption.getOriginalWidth(), lastOption.getOriginalHeight());
+        newOption.setPosition(lastOption.getOriginalX(), lastOption.getOriginalY() + lastOption.getOriginalHeight());
+        newOption.setText(text);
+        newOption.setActionText(actionText);
+        newOption.revalidate();
+        newOption.setEnabledListener(this::onTabEnabled);
+
+        this.options.add(newOption);
+
+        resizeTabsContainer();
+    }
+
+    void onTabEnabled(UIDropdownOption src) {
+        for (UIDropdownOption ui : this.options) {
+            if (ui == src) continue;
+            ui.setEnabled(false);
+        }
+
+        // close dropdown
+        this.widget.setHidden(true)
+            .revalidate();
+
+        if (this.tabEnabledListener != null) {
+            this.tabEnabledListener.onComponentEvent(src);
+        }
+    }
+
+    void resizeTabsContainer() {
+        Widget tabContainer = this.widget;
+        Widget[] children = tabContainer.getChildren();
+        if (children == null) {
+            return;
+        }
+
+        Widget lastOption = this.options.get(this.options.size() - 1).getWidget();
+
+        tabContainer.setOriginalHeight(lastOption.getOriginalY() + lastOption.getOriginalHeight() + BORDER_WIDTH);
+        tabContainer.revalidate();
+
+        // recalculates the position and sizes for the border and background widgets
+        for (Widget c : children) {
+            c.revalidate();
+        }
+    }
+}

--- a/src/main/java/com/logmaster/ui/generic/dropdown/UIDropdown.java
+++ b/src/main/java/com/logmaster/ui/generic/dropdown/UIDropdown.java
@@ -85,6 +85,14 @@ public class UIDropdown extends UIComponent {
         return null;
     }
 
+    public void setEnabledOption(String text) {
+        for (UIDropdownOption opt : this.options) {
+            if (opt.getText().equals(text)) {
+                opt.setEnabled(true);
+            }
+        }
+    }
+
     public void addOption(String text, String actionText) {
         Widget tabContainer = this.widget;
         Widget[] children = tabContainer.getChildren();

--- a/src/main/java/com/logmaster/ui/generic/dropdown/UIDropdownOption.java
+++ b/src/main/java/com/logmaster/ui/generic/dropdown/UIDropdownOption.java
@@ -1,0 +1,171 @@
+package com.logmaster.ui.generic.dropdown;
+
+import com.logmaster.ui.generic.ComponentEventListener;
+import com.logmaster.ui.generic.MenuAction;
+import com.logmaster.ui.generic.UIComponent;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.FontID;
+import net.runelite.api.ScriptEvent;
+import net.runelite.api.widgets.*;
+
+@Slf4j
+public class UIDropdownOption extends UIComponent {
+    private static final int TEXT_COLOR_INACTIVE = 0xFF981F;
+    private static final int TEXT_COLOR_HIGHLIGHT = 0xFFFFFF;
+    private static final int TEXT_COLOR_ACTIVE = 0xC8C8C8;
+
+    private static final int TEXT_OPACITY_INACTIVE = 0;
+    private static final int TEXT_OPACITY_ACTIVE = 128;
+
+    private static final int BG_OPACITY_INACTIVE = 255;
+    private static final int BG_OPACITY_ACTIVE = 230;
+
+    private static final String DEFAULT_ACTION_LABEL = "Enable";
+
+    @Getter
+    protected final boolean managed;
+
+    @Getter
+    private boolean enabled = false;
+
+    @Getter
+    protected String text;
+
+    @Getter
+    protected String actionText;
+
+    protected final Widget bgWidget;
+
+	protected final Widget labelWidget;
+
+	@Setter
+	private ComponentEventListener<UIDropdownOption> enabledListener;
+
+	public UIDropdownOption(Widget layerWidget) {
+        super(layerWidget);
+        this.managed = true;
+        this.bgWidget = this.widget.createChild(WidgetType.RECTANGLE);
+        this.labelWidget = this.widget.createChild(WidgetType.TEXT);
+
+        this.setup();
+        this.setupManaged();
+	}
+
+	public UIDropdownOption(Widget bgWidget, Widget labelWidget) {
+        super(labelWidget);
+        this.managed = false;
+        this.bgWidget = bgWidget;
+        this.labelWidget = labelWidget;
+
+        this.setup();
+	}
+
+    private void setup() {
+        this.setText(this.labelWidget.getText());
+        this.setActionText(DEFAULT_ACTION_LABEL);
+
+        // preserve current action label if possible
+        String[] originalActions = this.labelWidget.getActions();
+        if (originalActions != null && originalActions.length > 0) {
+            this.setActionText(originalActions[0]);
+        }
+
+        this.enabled = this.bgWidget.getOpacity() < BG_OPACITY_INACTIVE;
+        this.updateStatefulStyles();
+    }
+
+    private void setupManaged() {
+        this.widget.setXPositionMode(WidgetPositionMode.ABSOLUTE_RIGHT);
+
+        this.bgWidget.setFilled(true);
+        this.bgWidget.setTextColor(0xFFFFFF);
+        this.bgWidget.setWidthMode(WidgetSizeMode.MINUS);
+        this.bgWidget.setHeightMode(WidgetSizeMode.MINUS);
+
+        this.labelWidget.setTextShadowed(true);
+        this.labelWidget.setFontId(FontID.PLAIN_12);
+        this.labelWidget.setWidthMode(WidgetSizeMode.MINUS);
+        this.labelWidget.setHeightMode(WidgetSizeMode.MINUS);
+        this.labelWidget.setXTextAlignment(WidgetTextAlignment.CENTER);
+        this.labelWidget.setYTextAlignment(WidgetTextAlignment.CENTER);
+
+        this.setActionText(DEFAULT_ACTION_LABEL);
+        this.enabled = false;
+        this.updateStatefulStyles();
+    }
+
+    @Override
+    @Deprecated
+    public void addAction(String action, MenuAction callback) {
+        throw new RuntimeException("Cannot add actions to this component; use .setActionLabel() to rename single action");
+    }
+
+    @Override
+    public void setName(String name) {
+        this.bgWidget.setName(name + "-bg");
+        this.labelWidget.setName(name + "-label");
+    }
+
+    public void setText(String text) {
+        this.text = text;
+        this.labelWidget.setText(text);
+    }
+
+    public void setActionText(String actionText) {
+        this.actionText = actionText;
+
+        this.actions.clear();
+        super.addAction(this.actionText, () -> this.setEnabled(true));
+    }
+
+    public void setEnabled(boolean enabled) {
+        // prevents raising the events unnecessarily
+        if (this.enabled == enabled) return;
+
+        this.enabled = enabled;
+
+        if (this.enabled && this.enabledListener != null) {
+            this.enabledListener.onComponentEvent(this);
+        }
+
+        this.updateStatefulStyles();
+    }
+
+    @Override
+    protected void onMouseHover(ScriptEvent e) {
+        super.onMouseHover(e);
+
+        if (this.isEnabled()) return;
+        this.labelWidget.setTextColor(TEXT_COLOR_HIGHLIGHT);
+    }
+
+    @Override
+    protected void onMouseLeave(ScriptEvent e) {
+        super.onMouseLeave(e);
+
+        if (this.isEnabled()) return;
+        this.labelWidget.setTextColor(TEXT_COLOR_INACTIVE);
+    }
+
+    private void updateStatefulStyles() {
+        if (this.isEnabled()) {
+            this.bgWidget.setOpacity(BG_OPACITY_ACTIVE);
+            this.labelWidget.setTextColor(TEXT_COLOR_ACTIVE);
+            this.labelWidget.setOpacity(TEXT_OPACITY_ACTIVE);
+        } else {
+            this.bgWidget.setOpacity(BG_OPACITY_INACTIVE);
+            this.labelWidget.setTextColor(TEXT_COLOR_INACTIVE);
+            this.labelWidget.setOpacity(TEXT_OPACITY_INACTIVE);
+        }
+
+        this.revalidate();
+    }
+
+    public void revalidate() {
+        super.revalidate();
+        this.bgWidget.revalidate();
+        this.labelWidget.revalidate();
+    }
+}


### PR DESCRIPTION
As discussed in Discord, this PR changes the way the Tasks Dashboard can be accessed. Instead of the old _Tasks Dashboard_ checkbox on the top-left corner, it now adds an option to the hamburger menu dropdown. This also fixes the incompatibility with the WikiSync plugin.

## Old
![{482551E7-DCEC-40D7-B79B-1A4CA10F539C}](https://github.com/user-attachments/assets/270d9f04-4624-49c7-974d-8f23de33985b)


## New
![{ABC68914-2E3B-4FB1-AB71-F0B61903D4F7}](https://github.com/user-attachments/assets/6b840433-c823-4d82-8e21-53d6637f32fa)

