### PR TITLE
Fix remote list constantly loading

### DIFF
--- a/src/main/java/com/logmaster/ui/InterfaceManager.java
+++ b/src/main/java/com/logmaster/ui/InterfaceManager.java
@@ -308,6 +308,7 @@ public class InterfaceManager implements MouseListener, MouseWheelListener {
                     this.taskDashboard.setVisibility(false);
                     this.taskList.refreshTasks(0);
                     this.taskList.setVisibility(true);
+                    showTabs();
                 });
                 tabIndex++;
             }
@@ -404,8 +405,13 @@ public class InterfaceManager implements MouseListener, MouseWheelListener {
     }
 
     public void completeTask() {
+        boolean wasDashboardVisible = this.taskDashboard.isVisible();
         this.taskDashboard.updatePercentages();
         taskList.refreshTasks(0);
+        // Restore previous visibility state
+        this.taskDashboard.setVisibility(wasDashboardVisible);
+        this.taskList.setVisibility(!wasDashboardVisible);
+        showTabs();
     }
 
     public void clearCurrentTask() {

--- a/src/main/java/com/logmaster/ui/InterfaceManager.java
+++ b/src/main/java/com/logmaster/ui/InterfaceManager.java
@@ -400,7 +400,6 @@ public class InterfaceManager implements MouseListener, MouseWheelListener {
     public void rollTask(String description, int itemID, List<Task> tasks) {
         this.taskDashboard.setTask(description, itemID, tasks);
         this.taskDashboard.disableGenerateTask(false);
-        this.taskList.refreshTasks(0);
         this.taskDashboard.updatePercentages();
     }
 


### PR DESCRIPTION
This PR should ensure the remote list is only loaded once upon client launch and then cached.
If you disable the remote list while launched, it will use the local list.
If the initial request fails it will keep trying to get the list.